### PR TITLE
Fix broken git submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "zstr"]
 	path = zstr
-	url = https://github.com/mateidavid/zstr
+	url = https://github.com/mateidavid/zstr.git
 [submodule "concurrentqueue"]
 	path = concurrentqueue
-	url = https://github.com/cameron314/concurrentqueue
+	url = https://github.com/cameron314/concurrentqueue.git
 [submodule "parallel-hashmap"]
 	path = parallel-hashmap
 	url = https://github.com/greg7mdp/parallel-hashmap.git
 [submodule "BBHash"]
 	path = BBHash
-	url = git@github.com:maickrau/BBHash.git
+	url = https://github.com/maickrau/BBHash.git


### PR DESCRIPTION
I kept getting failed checkouts of the submodules
Turned out the module paths were broken.
This fixes it.

After this you can replaced your instructions with this I think
```
git checkout --recursive https://github.com/maickrau/GraphAligner.git
```
