### PR TITLE
L record may not have a CIGAR string

### DIFF
--- a/src/GfaGraph.cpp
+++ b/src/GfaGraph.cpp
@@ -266,9 +266,9 @@ GfaGraph GfaGraph::LoadFromStream(std::istream& file, bool allowVaryingOverlaps,
 			assert(fromstart == "+" || fromstart == "-");
 			assert(toend == "+" || toend == "-");
 			sstr >> overlap;
-			char dummyc;
+			char dummyc = 0;
 			sstr >> dummyc;
-			assert(dummyc == 'M' || (dummyc == 'S' && overlap == 0));
+			assert(dummyc == 'M' || (dummyc == 'S' && overlap == 0) || (dummyc == 0 && overlap == 0));
 			if (overlap < 0) throw CommonUtils::InvalidGraphException { "Edge overlap cannot be negative. Fix the graph" };
 			assert(overlap >= 0);
 			if (result.edgeOverlap != std::numeric_limits<size_t>::max() && (size_t)overlap != result.edgeOverlap)


### PR DESCRIPTION
If the first `L` record didn't contains a CIGAR string dummyc isn't set and result of assert at line [271](https://github.com/maickrau/GraphAligner/blob/2e4b0857b9c62b521b471bd52cb96c0cd428095f/src/GfaGraph.cpp#L271) is undefined.